### PR TITLE
Code review changes

### DIFF
--- a/mapbook-iOS/AppContext/AppContext+Login.swift
+++ b/mapbook-iOS/AppContext/AppContext+Login.swift
@@ -45,7 +45,7 @@ extension AppContext {
         
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
         
-        AppContext.shared.deleteAllLocalPackages()
-        AppContext.shared.portal = nil
+        self.deleteAllLocalPackages()
+        self.portal = nil
     }
 }

--- a/mapbook-iOS/AppContext/AppContext+Portal.swift
+++ b/mapbook-iOS/AppContext/AppContext+Portal.swift
@@ -149,7 +149,7 @@ extension AppContext {
     /*
      Method to download the package from a portal item. An AGSRequestOperation is
      created for download. The packages are first downloaded to the downloading 
-     directory and on successful completion they are moved to the donwloaded 
+     directory and on successful completion they are moved to the downloaded
      directory. It also keeps record of the items being currently downloaded. Once
      done, a DownloadCompleted notification is posted with the itemID of the downloaded
      package. The notification can be used to update UI.
@@ -192,10 +192,6 @@ extension AppContext {
         
         requestOperation.outputFileURL = downloadingFileURL
         requestOperation.sessionID = portalItem.itemID
-        
-//        requestOperation.progressHandler = { (downloaded, total) -> Void in
-//            print("Downloaded: \(downloaded)  Total: \(total)")
-//        }
         
         requestOperation.registerListener(self) { [weak self] (result, error) in
             

--- a/mapbook-iOS/AppContext/AppContext.swift
+++ b/mapbook-iOS/AppContext/AppContext.swift
@@ -98,9 +98,6 @@ class AppContext {
     //cancelable for the fetch call, in case it needs to be cancelled
     var fetchPortalItemsCancelable:AGSCancelable?
     
-    //list of current download operations, in case they need to be cancelled
-    //var downloadOperations:[AGSRequestOperation] = []
-    
     var downloadOperationQueue = AGSOperationQueue()
     
     //flag if fetching is in progress
@@ -175,6 +172,6 @@ class AppContext {
             }
         }
         
-        return AppMode.notSet
+        return .notSet
     }
 }


### PR DESCRIPTION
>- AppContext.swift:L102 - remove commented out line

Done
>- AppContext.swift:L178 - the other return statements don't include the `AppMode` enum prefix; can this be made to match those?  i.e., `.notSet`

Done
>- AppContext+Login.swift:L37 - this line uses `self.` whereas the code in `logoutUser()` uses `AppContext.shared.`; I'm assuming this is because those are in other extensions, but can the `self.` be changed to `AppContext.shared` in order to match the ones in `logoutUser()`?  Are there issues with doing that?

I have changed `AppContext.shared` to `self`. The method and portal property has internal access specifier, so it can be used among extensions in different files. Or other classes. The logout method might have been in some place, so when I moved it to AppContext, may be I forgot to change it. Good catch.
>- AppContext+Portal.swift:L152 - `donwloaded` is spelled incorrectly in the comment

Done
>- AppContext+Portal.swift:L196 - remove commented out code

Done

Thanks @mhdostal for the review.

cc: @zinfin