### PR TITLE
2.0.1 patch release: Improvements to app documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # Mapbook iOS
 This repo is home to the mobile mapbook app, an example application using the [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/). Replace the paper maps you use for field work with offline maps.
 
+<!-- MDTOC maxdepth:6 firsth1:0 numbering:0 flatten:0 bullets:1 updateOnSave:1 -->
+
+- [Features](#features)   
+- [Best Practices](#best-practices)   
+- [Detailed Documentation](#detailed-documentation)   
+- [Get Started](#get-started)   
+   - [Fork the repo](#fork-the-repo)   
+   - [Clone the repo](#clone-the-repo)   
+      - [Command line Git](#command-line-git)   
+   - [Configuring a Remote for a Fork](#configuring-a-remote-for-a-fork)   
+   - [Configure the app](#configure-the-app)   
+      - [1. Register an Application](#1-register-an-application)   
+      - [2. Configuring the project](#2-configuring-the-project)   
+      - [3. License the app (Optional)](#3-license-the-app-optional)   
+- [Learn More](#learn-more)   
+- [Requirements](#requirements)   
+- [Contributing](#contributing)   
+- [MDTOC](#mdtoc)   
+- [Licensing](#licensing)   
+
+<!-- /MDTOC -->
+---
+
 ## Features
 - Mobile map packages
 - Feature layers
@@ -20,6 +43,9 @@ The project also demonstrates some patterns for building real-world apps around 
 * Asynchronous service and UI coding patterns
 * Internal application communication patterns
 * FileManager used with ArcGIS
+
+## Detailed Documentation
+Read the [docs](./docs/README.md) for a detailed explanation of the application, including its architecture and how it leverages the ArcGIS platform, as well as how you can begin using the app right away.
 
 ## Get Started
 You will need [Xcode 11](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) with Swift 5 and the [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/latest/swift/guide/install.htm) (v100.1 or later) installed locally.
@@ -109,6 +135,9 @@ Anyone and everyone is welcome to [contribute](CONTRIBUTING.md). We do accept pu
 1. Report issues
 1. Contribute code
 1. Improve documentation
+
+## MDTOC
+Generation of this and other documents' table of contents in this repository was performed using the [MDTOC package for Atom](https://atom.io/packages/atom-mdtoc).
 
 ## Licensing
 Copyright 2017 Esri

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# v2.0.1
+
+- Adds doc table of contents to root README.md and docs/index.md
+- Renames docs/index.md to [docs/README.md](/docs/README.md)
+
 # v2.0.0
 
 * Brand new UI & UX
@@ -25,7 +30,7 @@
 
 # v1.1.2
 
-* Adds [app documentation](/docs/index.md) from the ArcGIS for Developers site.
+* Adds [app documentation](/docs/README.md) from the ArcGIS for Developers site.
 
 # v1.1.1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,40 @@
+# Contents
+
+<!-- MDTOC maxdepth:6 firsth1:0 numbering:0 flatten:0 bullets:1 updateOnSave:1 -->
+
+- [Description](#description)   
+- [Design considerations](#design-considerations)   
+   - [Portal](#portal)   
+      - [Portal Authentication](#portal-authentication)   
+      - [Search portal](#search-portal)   
+   - [Device](#device)   
+      - [Exported `.mmpk` Uniform Type Identifier](#exported-mmpk-uniform-type-identifier)   
+- [App developer patterns](#app-developer-patterns)   
+   - [Authentication](#authentication)   
+   - [Identify](#identify)   
+   - [Displaying identify results](#displaying-identify-results)   
+   - [TOC & legend](#toc-legend)   
+   - [Bookmarks](#bookmarks)   
+   - [Suggestions & search](#suggestions-search)   
+   - [Check for mobile map package updates](#check-for-mobile-map-package-updates)   
+- [Create your own mobile map packages](#create-your-own-mobile-map-packages)   
+   - [Data scenario](#data-scenario)   
+   - [Authoring the data for viewing](#authoring-the-data-for-viewing)   
+      - [Setting symbology](#setting-symbology)   
+      - [Creating a reference backdrop](#creating-a-reference-backdrop)   
+      - [Creating locators](#creating-locators)   
+      - [Setting bookmarks](#setting-bookmarks)   
+      - [Metadata and thumbnails](#metadata-and-thumbnails)   
+   - [Packaging for consumption](#packaging-for-consumption)   
+      - [Including multiple maps](#including-multiple-maps)   
+      - [Including the locator](#including-the-locator)   
+   - [Sharing the mobile map package](#sharing-the-mobile-map-package)   
+      - [Using the ArcGIS Pro 'Share Package' tool](#using-the-arcgis-pro-share-package-tool)   
+      - [Uploading directly from the 'My Content' page](#uploading-directly-from-the-my-content-page)   
+
+<!-- /MDTOC -->
+---
+
 ## Description
 
 Learn how to create and share mobile map packages so that you can take your organization's maps offline and view them in the field with an iOS app. This example demonstrate how to:

--- a/mapbook-iOS.xcodeproj/project.pbxproj
+++ b/mapbook-iOS.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				INFOPLIST_FILE = "mapbook-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.0.1;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.esri.arcgisruntime.opensourceapps.mapbook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -725,7 +725,7 @@
 				INFOPLIST_FILE = "mapbook-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.0.1;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.esri.arcgisruntime.opensourceapps.mapbook;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/mapbook-iOS/Info.plist
+++ b/mapbook-iOS/Info.plist
@@ -4,20 +4,20 @@
 <dict>
 	<key>AGSConfiguration</key>
 	<dict>
-		<key>SearchSuggestionResultSize</key>
-		<string>12</string>
-		<key>DefaultPortalBrowserSearchString</key>
-		<string>Offline Mapbook</string>
 		<key>AppURLScheme</key>
 		<string>mapbook</string>
 		<key>AuthURLPath</key>
 		<string>auth</string>
+		<key>DefaultPortalBrowserSearchString</key>
+		<string>Offline Mapbook</string>
 		<key>DefaultPortalURLString</key>
 		<string>https://arcgis.com</string>
 		<key>KeychainIdentifier</key>
 		<string>com.mapbook</string>
 		<key>PortalItemsQuerySize</key>
 		<integer>20</integer>
+		<key>SearchSuggestionResultSize</key>
+		<string>12</string>
 	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
@@ -55,7 +55,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>ArcGIS SDK requires access to the device&apos;s photo library.</string>
+	<string>ArcGIS SDK requires access to the device's photo library.</string>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
This PR introduces a TOC to various README files. The TOC was generated using MDTOC. 

You can ignore the changes in `mapbook-iOS/Info.plist`, this was performed automatically by Xcode.