### PR TITLE
Increment deployment target from iOS 12 to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ Learn more about the App Architecture and usage [here](/docs/index.md).
 * [Xcode 11 and Swift 5](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
 * [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A), version 100.10.
 * [ArcGIS Runtime Toolkit for iOS](https://github.com/Esri/arcgis-runtime-toolkit-ios), version 100.10.
+* Device or Simulator running iOS 13.0 or later.
 
-**Note:** Starting from the 100.8 release, the *ArcGIS Runtime SDK for iOS* uses Apple's [Metal](https://developer.apple.com/metal/) framework to render maps and scenes. In order to run your app in a simulator you must be developing on **macOS Catalina**, using **Xcode 11**, and simulating **iOS 13**.
+**Note:** Starting from the 100.8 release, the ArcGIS Runtime SDK for iOS uses Apple's Metal framework to display maps and scenes. However, Xcode does not support Metal based rendering in any version of iOS simulator on macOS Mojave. If you are developing map or scene based apps in these environments, you will need test and debug them on a physical device instead of the simulator.
 
 **Note:** The 100.10 release of the ArcGIS Runtime SDK for iOS replaces the installed "fat framework" `ArcGIS.framework` with a new binary framework `ArcGIS.xcframework`.  It also changes the location of the installed framework file and removes the need for the `strip-frameworks.sh` Build Phase.  These changes have been incorporated in the lastest release of *Mapbook iOS*.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
     - The `ArcGIS.framework` framework has been replaced with `ArcGIS.xcframework`.
     - The Build Phase which ran the `strip-frameworks.sh` shell script is no longer necessary.
 - Certification for the 100.10.0 release of the ArcGIS Runtime SDK for iOS.
+- Increments app deployment targets to iOS 13.0, drops support for iOS 12.0.
 
 # v2.0.2
 

--- a/mapbook-iOS.xcodeproj/project.pbxproj
+++ b/mapbook-iOS.xcodeproj/project.pbxproj
@@ -672,7 +672,7 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "mapbook-iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -696,7 +696,7 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "mapbook-iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/mapbook-iOS/AppDelegate.swift
+++ b/mapbook-iOS/AppDelegate.swift
@@ -74,34 +74,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func modifyAppearance() {
         
-        if #available(iOS 13.0, *) {
-            let navBarAppearance: UINavigationBarAppearance = {
-                let navBarAppearance = UINavigationBarAppearance()
-                navBarAppearance.configureWithOpaqueBackground()
-                navBarAppearance.buttonAppearance = {
-                    let buttonAppearance = UIBarButtonItemAppearance(style: .plain)
-                    buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    buttonAppearance.focused.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    buttonAppearance.highlighted.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    return buttonAppearance
-                }()
-                navBarAppearance.doneButtonAppearance = {
-                    let doneButtonAppearance = UIBarButtonItemAppearance(style: .done)
-                    doneButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    doneButtonAppearance.focused.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    doneButtonAppearance.highlighted.titleTextAttributes = [.foregroundColor: UIColor.primary]
-                    return doneButtonAppearance
-                }()
-                return navBarAppearance
+        let navBarAppearance: UINavigationBarAppearance = {
+            let navBarAppearance = UINavigationBarAppearance()
+            navBarAppearance.configureWithOpaqueBackground()
+            navBarAppearance.buttonAppearance = {
+                let buttonAppearance = UIBarButtonItemAppearance(style: .plain)
+                buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                buttonAppearance.focused.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                buttonAppearance.highlighted.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                return buttonAppearance
             }()
-            
-            UINavigationBar.appearance().standardAppearance = navBarAppearance
-            UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
-            UINavigationBar.appearance().compactAppearance = navBarAppearance
-        }
-        else {
-            UINavigationBar.appearance().tintColor = .primary
-        }
+            navBarAppearance.doneButtonAppearance = {
+                let doneButtonAppearance = UIBarButtonItemAppearance(style: .done)
+                doneButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                doneButtonAppearance.focused.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                doneButtonAppearance.highlighted.titleTextAttributes = [.foregroundColor: UIColor.primary]
+                return doneButtonAppearance
+            }()
+            return navBarAppearance
+        }()
+        
+        UINavigationBar.appearance().standardAppearance = navBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
+        UINavigationBar.appearance().compactAppearance = navBarAppearance
         
         UIButton.appearance().tintColor = .primary
 

--- a/mapbook-iOS/View controllers/Map/MapViewController.swift
+++ b/mapbook-iOS/View controllers/Map/MapViewController.swift
@@ -145,11 +145,7 @@ class MapViewController: UIViewController {
     private func showSearch(result: AGSGeocodeResult) {
         shouldShowSearch.toggle()
         if let location = result.displayLocation, let extent = result.extent {
-            if #available(iOS 13.0, *) {
-                mapView.callout.accessoryButtonType = .close
-            } else {
-                mapView.callout.isAccessoryButtonHidden = true
-            }
+            mapView.callout.accessoryButtonType = .close
             mapView.callout.delegate = self
             mapView.callout.title = result.label
             mapView.callout.show(


### PR DESCRIPTION
This PR drops support for iOS 12, removes properties deprecated by iOS 13, and increments the deployment target to iOS 13.
[[Related Issue]](https://github.com/ArcGIS/open-source-apps/issues/458)